### PR TITLE
Add dark mode toggle

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
-import './globals.css';
-import type { Metadata } from 'next';
-import { Inter } from 'next/font/google';
+import './globals.css'
+import type { Metadata } from 'next'
+import { Inter } from 'next/font/google'
+import { ThemeProvider } from '@/components/theme-provider'
 
 const inter = Inter({
   subsets: ['latin'],
@@ -15,11 +16,13 @@ export const metadata: Metadata = {
 export default function RootLayout({
   children,
 }: {
-  children: React.ReactNode;
+  children: React.ReactNode
 }) {
   return (
-    <html lang="en">
-      <body className={`${inter.variable} font-sans`}>{children}</body>
+    <html lang="en" suppressHydrationWarning>
+      <body className={`${inter.variable} font-sans`}>
+        <ThemeProvider>{children}</ThemeProvider>
+      </body>
     </html>
-  );
+  )
 }

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useTheme } from 'next-themes'
+import { Sun, Moon } from 'lucide-react'
+import { useState, useEffect } from 'react'
+import { cn } from '@/lib/utils'
+
+export function ThemeToggle({ className }: { className?: string }) {
+  const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  if (!mounted) return null
+
+  const isDark = theme === 'dark'
+
+  return (
+    <button
+      type="button"
+      onClick={() => setTheme(isDark ? 'light' : 'dark')}
+      className={cn(
+        'w-8 h-8 rounded-lg flex items-center justify-center',
+        'hover:bg-accent hover:text-accent-foreground transition-colors duration-200',
+        className
+      )}
+      title="Toggle theme"
+    >
+      {isDark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+    </button>
+  )
+}
+

--- a/components/VerticalMenu.tsx
+++ b/components/VerticalMenu.tsx
@@ -2,6 +2,7 @@
 
 import { Table2, PenLine, Network, HelpCircle, UserCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { ThemeToggle } from "@/components/ThemeToggle";
 
 interface VerticalMenuProps {
   activeView: string;
@@ -55,6 +56,7 @@ export function VerticalMenu({ activeView, onViewChange }: VerticalMenuProps) {
             <item.icon className="w-4 h-4" />
           </button>
         ))}
+        <ThemeToggle />
       </div>
     </nav>
   );

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import { ThemeProvider as NextThemeProvider } from 'next-themes'
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <NextThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      {children}
+    </NextThemeProvider>
+  )
+}


### PR DESCRIPTION
## Summary
- add ThemeProvider and ThemeToggle components
- include ThemeProvider in root layout
- add theme toggle button to the vertical menu

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68594c3465b88323a8402c75b096d803