### PR TITLE
Fix label typo in ApplicationForm

### DIFF
--- a/components/ApplicationForm.tsx
+++ b/components/ApplicationForm.tsx
@@ -338,7 +338,7 @@ export function ApplicationForm({ onSubmit }: ApplicationFormProps) {
                   { value: "Utenza Applicativa", label: "Utenza applicativa" },
                   { value: "Password ADFS (O365)", label: "Password ADFS (O365)" },
                   { value: "Password applicazione", label: "Password applicazione" },
-                  { value: "Password di domino (LDAP)", label: "Password di domino (LDAP)" }
+                  { value: "Password di dominio (LDAP)", label: "Password di dominio (LDAP)" }
                 ]}
                 multiple
               />


### PR DESCRIPTION
## Summary
- correct the Italian text for the LDAP password option in `ApplicationForm`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b5cc5d608323b786bc3d5dbde4a3