### PR TITLE
Fix duplicate toast listeners

### DIFF
--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1);
       }
     };
-  }, [state]);
+  }, []);
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- prevent multiple listeners from piling up in `useToast`

## Testing
- `npm run lint` *(fails: Invalid Options)*

------
https://chatgpt.com/codex/tasks/task_e_6859cdffbab48323b846d217a00f8bfc