### PR TITLE
Enable edit context menu on graph

### DIFF
--- a/components/NetworkGraph.tsx
+++ b/components/NetworkGraph.tsx
@@ -32,10 +32,16 @@ import {
   getConnectedApplicationLabels,
   saveApplication,
   saveFlow,
-  getFlowLabels, 
+  getFlowLabels,
   getApplicationLabels
 } from "@/lib/neo4jUtils";
 import { MultiselectDropdown } from "./MultiselectDropdown";
+import {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+} from "@/components/ui/context-menu";
 
 interface NetworkWithBody extends Network {
   body: {
@@ -242,8 +248,20 @@ export function NetworkGraph() {
     data: {},
     type: "",
   });
+  const [contextMenuOpen, setContextMenuOpen] = useState(false);
+  const [contextMenuPos, setContextMenuPos] = useState({ x: 0, y: 0 });
+  const [contextTarget, setContextTarget] = useState<{ type: "node" | "edge" | null; id?: string }>({ type: null });
   const [appLabels, setAppLabels] = useState([]);
   const [flowLabels, setFlowLabels] = useState([]);
+
+  const handleContextEdit = () => {
+    setContextMenuOpen(false);
+    if (contextTarget.type === "node") {
+      setIsApplicationDialogOpen(true);
+    } else if (contextTarget.type === "edge") {
+      setIsFlowDialogOpen(true);
+    }
+  };
 
   const handleQueryResults = useCallback((results: any[]) => {
     const nodes = new Map();
@@ -647,11 +665,19 @@ export function NetworkGraph() {
         }
       });
 
-      //Visualizzare la modale di modifica
+      // Show custom context menu on right click
       networkRef.current.on("oncontext", (params) => {
         params.event.preventDefault();
-        if (params.nodes.length > 0) {
-          const nodeId = params.nodes[0];
+        if (!networkRef.current) return;
+
+        const pointer = params.pointer.DOM;
+        const nodeId = networkRef.current.getNodeAt(pointer);
+        const edgeId = networkRef.current.getEdgeAt(pointer);
+
+        if (!nodeId && !edgeId) return;
+
+        if (nodeId) {
+          networkRef.current.selectNodes([nodeId]);
           const nodeData = dataTransformedRef.current[nodeId];
           nodeData["elementId"] = nodeId;
           nodeData["type"] = "application";
@@ -660,17 +686,17 @@ export function NetworkGraph() {
             hasRelationship: params.edges.length > 0 ? true : false,
           };
           setApplicationData(appData);
-          setIsApplicationDialogOpen(true);
-        }
-
-        if (params.edges.length > 0 && params.nodes.length === 0) {
-          const edgeId = params.edges[0];
+          setContextTarget({ type: "node", id: nodeId });
+        } else if (edgeId) {
+          networkRef.current.selectEdges([edgeId]);
           const edgeData = dataTransformedRef.current[edgeId];
           edgeData["elementId"] = edgeId;
           setFlowData(edgeData);
-          //console.log('Clicked edge data:', edgeData);
-          setIsFlowDialogOpen(true);
+          setContextTarget({ type: "edge", id: edgeId });
         }
+
+        setContextMenuPos({ x: params.event.clientX, y: params.event.clientY });
+        setContextMenuOpen(true);
       });
 
       networkRef.current.once("afterDrawing", () => {
@@ -854,13 +880,22 @@ export function NetworkGraph() {
         </div>
       </div>
 
-      <div ref={containerRef} className="flex-1 min-h-0">
-        {isLoading && (
-          <div className="flex items-center justify-center h-full">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+      <ContextMenu open={contextMenuOpen} onOpenChange={setContextMenuOpen}>
+        <ContextMenuTrigger asChild>
+          <div ref={containerRef} className="flex-1 min-h-0">
+            {isLoading && (
+              <div className="flex items-center justify-center h-full">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+              </div>
+            )}
           </div>
-        )}
-      </div>
+        </ContextMenuTrigger>
+        <ContextMenuContent
+          style={{ position: "fixed", top: contextMenuPos.y, left: contextMenuPos.x }}
+        >
+          <ContextMenuItem onSelect={handleContextEdit}>Edit</ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
 
       <div className="mt-4 px-4 pb-4">
         <QueryInput

--- a/components/NetworkGraph.tsx
+++ b/components/NetworkGraph.tsx
@@ -263,19 +263,12 @@ export function NetworkGraph() {
     }
   };
 
-  const handleContainerContextMenu = (
-    event: React.MouseEvent<HTMLDivElement>
-  ) => {
-    event.preventDefault();
-    if (!networkRef.current || !containerRef.current) return;
+  const handleNetworkContextMenu = (params: any) => {
+    params.event.preventDefault();
+    if (!networkRef.current) return;
 
-    const rect = containerRef.current.getBoundingClientRect();
-    const pointer = {
-      x: event.clientX - rect.left,
-      y: event.clientY - rect.top,
-    };
-    const nodeId = networkRef.current.getNodeAt(pointer);
-    const edgeId = networkRef.current.getEdgeAt(pointer);
+    const nodeId = params.nodes[0];
+    const edgeId = params.edges[0];
 
     if (!nodeId && !edgeId) {
       setContextMenuOpen(false);
@@ -302,7 +295,8 @@ export function NetworkGraph() {
       setContextTarget({ type: "edge", id: edgeId });
     }
 
-    setContextMenuPos({ x: event.clientX, y: event.clientY });
+    const { x, y } = params.pointer.DOM;
+    setContextMenuPos({ x, y });
     setContextMenuOpen(true);
   };
 
@@ -709,6 +703,7 @@ export function NetworkGraph() {
       });
 
 
+      networkRef.current.on("oncontext", handleNetworkContextMenu);
 
       networkRef.current.once("afterDrawing", () => {
         networkRef.current?.fit();
@@ -896,7 +891,6 @@ export function NetworkGraph() {
           <div
             ref={containerRef}
             className="flex-1 min-h-0"
-            onContextMenu={handleContainerContextMenu}
           >
             {isLoading && (
               <div className="flex items-center justify-center h-full">

--- a/components/NetworkGraph.tsx
+++ b/components/NetworkGraph.tsx
@@ -38,7 +38,6 @@ import {
 import { MultiselectDropdown } from "./MultiselectDropdown";
 import {
   ContextMenu,
-  ContextMenuTrigger,
   ContextMenuContent,
   ContextMenuItem,
 } from "@/components/ui/context-menu";
@@ -261,6 +260,45 @@ export function NetworkGraph() {
     } else if (contextTarget.type === "edge") {
       setIsFlowDialogOpen(true);
     }
+  };
+
+  const handleContainerContextMenu = (
+    event: React.MouseEvent<HTMLDivElement>
+  ) => {
+    event.preventDefault();
+    if (!networkRef.current) return;
+
+    const pointer = { x: event.clientX, y: event.clientY };
+    const nodeId = networkRef.current.getNodeAt(pointer);
+    const edgeId = networkRef.current.getEdgeAt(pointer);
+
+    if (!nodeId && !edgeId) {
+      setContextMenuOpen(false);
+      return;
+    }
+
+    if (nodeId) {
+      networkRef.current.selectNodes([nodeId]);
+      const nodeData = dataTransformedRef.current[nodeId];
+      nodeData["elementId"] = nodeId;
+      nodeData["type"] = "application";
+      const appData = {
+        nodeData,
+        hasRelationship:
+          networkRef.current.getConnectedEdges(nodeId).length > 0,
+      };
+      setApplicationData(appData);
+      setContextTarget({ type: "node", id: nodeId });
+    } else if (edgeId) {
+      networkRef.current.selectEdges([edgeId]);
+      const edgeData = dataTransformedRef.current[edgeId];
+      edgeData["elementId"] = edgeId;
+      setFlowData(edgeData);
+      setContextTarget({ type: "edge", id: edgeId });
+    }
+
+    setContextMenuPos({ x: event.clientX, y: event.clientY });
+    setContextMenuOpen(true);
   };
 
   const handleQueryResults = useCallback((results: any[]) => {
@@ -665,39 +703,7 @@ export function NetworkGraph() {
         }
       });
 
-      // Show custom context menu on right click
-      networkRef.current.on("oncontext", (params) => {
-        params.event.preventDefault();
-        if (!networkRef.current) return;
 
-        const pointer = params.pointer.DOM;
-        const nodeId = networkRef.current.getNodeAt(pointer);
-        const edgeId = networkRef.current.getEdgeAt(pointer);
-
-        if (!nodeId && !edgeId) return;
-
-        if (nodeId) {
-          networkRef.current.selectNodes([nodeId]);
-          const nodeData = dataTransformedRef.current[nodeId];
-          nodeData["elementId"] = nodeId;
-          nodeData["type"] = "application";
-          const appData = {
-            nodeData,
-            hasRelationship: params.edges.length > 0 ? true : false,
-          };
-          setApplicationData(appData);
-          setContextTarget({ type: "node", id: nodeId });
-        } else if (edgeId) {
-          networkRef.current.selectEdges([edgeId]);
-          const edgeData = dataTransformedRef.current[edgeId];
-          edgeData["elementId"] = edgeId;
-          setFlowData(edgeData);
-          setContextTarget({ type: "edge", id: edgeId });
-        }
-
-        setContextMenuPos({ x: params.event.clientX, y: params.event.clientY });
-        setContextMenuOpen(true);
-      });
 
       networkRef.current.once("afterDrawing", () => {
         networkRef.current?.fit();
@@ -881,15 +887,17 @@ export function NetworkGraph() {
       </div>
 
       <ContextMenu open={contextMenuOpen} onOpenChange={setContextMenuOpen}>
-        <ContextMenuTrigger asChild>
-          <div ref={containerRef} className="flex-1 min-h-0">
-            {isLoading && (
-              <div className="flex items-center justify-center h-full">
-                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
-              </div>
-            )}
-          </div>
-        </ContextMenuTrigger>
+        <div
+          ref={containerRef}
+          className="flex-1 min-h-0"
+          onContextMenu={handleContainerContextMenu}
+        >
+          {isLoading && (
+            <div className="flex items-center justify-center h-full">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+            </div>
+          )}
+        </div>
         <ContextMenuContent
           style={{ position: "fixed", top: contextMenuPos.y, left: contextMenuPos.x }}
         >

--- a/components/NetworkGraph.tsx
+++ b/components/NetworkGraph.tsx
@@ -40,6 +40,7 @@ import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuTrigger,
 } from "@/components/ui/context-menu";
 
 interface NetworkWithBody extends Network {
@@ -266,9 +267,13 @@ export function NetworkGraph() {
     event: React.MouseEvent<HTMLDivElement>
   ) => {
     event.preventDefault();
-    if (!networkRef.current) return;
+    if (!networkRef.current || !containerRef.current) return;
 
-    const pointer = { x: event.clientX, y: event.clientY };
+    const rect = containerRef.current.getBoundingClientRect();
+    const pointer = {
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top,
+    };
     const nodeId = networkRef.current.getNodeAt(pointer);
     const edgeId = networkRef.current.getEdgeAt(pointer);
 
@@ -887,17 +892,19 @@ export function NetworkGraph() {
       </div>
 
       <ContextMenu open={contextMenuOpen} onOpenChange={setContextMenuOpen}>
-        <div
-          ref={containerRef}
-          className="flex-1 min-h-0"
-          onContextMenu={handleContainerContextMenu}
-        >
-          {isLoading && (
-            <div className="flex items-center justify-center h-full">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
-            </div>
-          )}
-        </div>
+        <ContextMenuTrigger asChild>
+          <div
+            ref={containerRef}
+            className="flex-1 min-h-0"
+            onContextMenu={handleContainerContextMenu}
+          >
+            {isLoading && (
+              <div className="flex items-center justify-center h-full">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+              </div>
+            )}
+          </div>
+        </ContextMenuTrigger>
         <ContextMenuContent
           style={{ position: "fixed", top: contextMenuPos.y, left: contextMenuPos.x }}
         >


### PR DESCRIPTION
## Summary
- enable right-click context menu on graph nodes and edges
- add edit option for applications and flows when right-clicking

## Testing
- `npm run lint` *(fails: Invalid Options)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859cf64a30c83239358969e113294e0