### PR TITLE
Show initiator/target in flow table

### DIFF
--- a/components/TablesPage.tsx
+++ b/components/TablesPage.tsx
@@ -87,6 +87,8 @@ const appColumns = [
 
 const flowColumns = [
   "flow_id",
+  "initiator",
+  "target",
   "name",
   "description",
   "communication_mode",
@@ -149,6 +151,8 @@ export function TablesPage() {
           result.map((record: any) => ({
             id: record.r.elementId,
             type: "flow",
+            initiator: record.initiator,
+            target: record.target,
             ...record.r.properties,
           }))
         );

--- a/lib/neo4jUtils.ts
+++ b/lib/neo4jUtils.ts
@@ -145,7 +145,7 @@ export const deleteApplication = async (data: any) => {
 export const getFlows = async () => {
   try {
     const results = await executeQuery(
-      "MATCH ()-[r:flow]->() RETURN r",
+      "MATCH (i:Application)-[r:flow]->(t:Application) RETURN r, i.name AS initiator, t.name AS target",
       {},
       new AbortController().signal
     );


### PR DESCRIPTION
## Summary
- include initiator and target name in `getFlows`
- display initiator and target columns in Flows table

## Testing
- `npm run lint` *(fails: Unknown options useEslintrc etc.)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b0d6ddc3c8323a1198dc0200a8473