### PR TITLE
Add theme toggle

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css';
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
+import { ThemeProvider } from '@/components/ThemeProvider';
 
 const inter = Inter({
   subsets: ['latin'],
@@ -18,8 +19,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
-      <body className={`${inter.variable} font-sans`}>{children}</body>
+    <html lang="en" suppressHydrationWarning>
+      <body className={`${inter.variable} font-sans`}>
+        <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
+          {children}
+        </ThemeProvider>
+      </body>
     </html>
   );
 }

--- a/components/ThemeProvider.tsx
+++ b/components/ThemeProvider.tsx
@@ -1,0 +1,7 @@
+"use client";
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type { ThemeProviderProps } from "next-themes";
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+import { Moon, Sun } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) {
+    return null;
+  }
+
+  const isDark = theme === "dark";
+
+  return (
+    <button
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      className={cn(
+        "w-8 h-8 rounded-lg flex items-center justify-center",
+        "hover:bg-accent hover:text-accent-foreground",
+        "transition-colors duration-200"
+      )}
+      title={isDark ? "Switch to light mode" : "Switch to dark mode"}
+    >
+      {isDark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+    </button>
+  );
+}

--- a/components/VerticalMenu.tsx
+++ b/components/VerticalMenu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Table2, PenLine, Network, HelpCircle, UserCircle } from "lucide-react";
+import { ThemeToggle } from "./ThemeToggle";
 import { cn } from "@/lib/utils";
 
 interface VerticalMenuProps {
@@ -55,6 +56,7 @@ export function VerticalMenu({ activeView, onViewChange }: VerticalMenuProps) {
             <item.icon className="w-4 h-4" />
           </button>
         ))}
+        <ThemeToggle />
       </div>
     </nav>
   );


### PR DESCRIPTION
## Summary
- add NextThemes provider
- add theme toggle button to the vertical menu
- allow switching between light and dark theme

## Testing
- `npm run lint` *(fails: Invalid Options)*
- `npm test` *(fails: jest not found)*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_685ba3b2eb688323853fed9476b671d6