### PR TITLE
Ensure table headers stay visible while scrolling

### DIFF
--- a/components/TablesPage.tsx
+++ b/components/TablesPage.tsx
@@ -493,11 +493,8 @@ export function TablesPage() {
           </div>
         </div>
 
-        <div className="flex-1 min-h-0 border rounded-md">
-          <div className="h-full overflow-auto">
-            <div className="inline-block min-w-full align-middle">
-              <div className="overflow-hidden">
-                <Table>
+        <div className="flex-1 min-h-0 overflow-auto border rounded-md">
+          <Table className="min-w-full">
                   <TableHeader>
                     <TableRow>
                       <TableHead className="sticky top-0 z-10 bg-background whitespace-nowrap shadow-sm">
@@ -545,9 +542,6 @@ export function TablesPage() {
                     ))}
                   </TableBody>
                 </Table>
-              </div>
-            </div>
-          </div>
         </div>
 
         <div className="text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- keep the header visible on scroll by simplifying table wrapper structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c5e8fac208323a817b0cb79fcfa9d