### PR TITLE
Improve network graph physics

### DIFF
--- a/components/NetworkGraph.tsx
+++ b/components/NetworkGraph.tsx
@@ -79,7 +79,7 @@ const options = {
     barnesHut: {
       gravitationalConstant: -800,
       centralGravity: 0.05,
-      springLength: 150,
+      springLength: 300,
       springConstant: 0.02,
     },
     stabilization: {
@@ -231,9 +231,22 @@ export function NetworkGraph() {
   const physicsStateRef = useRef(isPhysicsEnabled);
 
   const schedulePhysicsStop = useCallback(() => {
-    setTimeout(() => {
+    const accelerate = setTimeout(() => {
+      networkRef.current?.setOptions({
+        physics: {
+          stabilization: { iterations: 100, updateInterval: 5 },
+        },
+      });
+      networkRef.current?.stabilize();
+    }, 4500);
+    const stop = setTimeout(() => {
       networkRef.current?.stopSimulation();
+      clearTimeout(accelerate);
     }, 5000);
+    return () => {
+      clearTimeout(accelerate);
+      clearTimeout(stop);
+    };
   }, []);
   const [graphData, setGraphData] = useState<{
     nodes: any[];

--- a/components/NetworkGraph.tsx
+++ b/components/NetworkGraph.tsx
@@ -84,8 +84,8 @@ const options = {
     },
     stabilization: {
       enabled: true,
-      iterations: 1000,
-      updateInterval: 50,
+      iterations: 200,
+      updateInterval: 25,
       onlyDynamicEdges: false,
       fit: true,
     },
@@ -229,6 +229,12 @@ export function NetworkGraph() {
   const [isFlowDialogOpen, setIsFlowDialogOpen] = useState(false);
   const [isPhysicsEnabled, setIsPhysicsEnabled] = useState(false);
   const physicsStateRef = useRef(isPhysicsEnabled);
+
+  const schedulePhysicsStop = useCallback(() => {
+    setTimeout(() => {
+      networkRef.current?.stopSimulation();
+    }, 5000);
+  }, []);
   const [graphData, setGraphData] = useState<{
     nodes: any[];
     edges: any[];
@@ -492,6 +498,9 @@ export function NetworkGraph() {
           enabled: newPhysicsState,
         },
       });
+      if (newPhysicsState) {
+        schedulePhysicsStop();
+      }
     }
   }, [isPhysicsEnabled]);
 
@@ -598,6 +607,9 @@ export function NetworkGraph() {
                 },
               },
             });
+            if (isPhysicsEnabled) {
+              schedulePhysicsStop();
+            }
           }
         }, 500);
       }
@@ -637,6 +649,9 @@ export function NetworkGraph() {
         networkRef.current?.setOptions({
           physics: { enabled: physicsStateRef.current },
         });
+        if (physicsStateRef.current) {
+          schedulePhysicsStop();
+        }
         if (!physicsStateRef.current) {
           networkRef.current?.redraw();
         }

--- a/components/NetworkGraph.tsx
+++ b/components/NetworkGraph.tsx
@@ -77,10 +77,10 @@ const options = {
   physics: {
     enabled: false,
     barnesHut: {
-      gravitationalConstant: -2000,
-      centralGravity: 0.3,
-      springLength: 200,
-      springConstant: 0.04,
+      gravitationalConstant: -800,
+      centralGravity: 0.05,
+      springLength: 150,
+      springConstant: 0.02,
     },
     stabilization: {
       enabled: true,
@@ -637,6 +637,9 @@ export function NetworkGraph() {
         networkRef.current?.setOptions({
           physics: { enabled: physicsStateRef.current },
         });
+        if (!physicsStateRef.current) {
+          networkRef.current?.redraw();
+        }
       });
 
       networkRef.current.on("doubleClick", (params) => {


### PR DESCRIPTION
## Summary
- tone down vis-network physics settings
- redraw the graph after drag when physics is disabled to keep edges aligned

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d44dc84c48323bdefc020f164c379