### PR TITLE
Add color customization for graph

### DIFF
--- a/components/ColorConfigDialog.tsx
+++ b/components/ColorConfigDialog.tsx
@@ -85,7 +85,7 @@ export function ColorConfigDialog({
 }: ColorConfigDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[600px] h-[80vh] flex flex-col">
+      <DialogContent className="sm:max-w-[600px] h-[80vh] flex flex-col z-[700]">
         <DialogHeader>
           <DialogTitle>Color configuration</DialogTitle>
         </DialogHeader>

--- a/components/ColorConfigDialog.tsx
+++ b/components/ColorConfigDialog.tsx
@@ -4,12 +4,163 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 export interface ColorRule {
   field: string;
   value: string;
   color: string;
 }
+
+interface FieldOption {
+  value: string;
+  label: string;
+  values: string[];
+}
+
+const nodeFieldOptions: FieldOption[] = [
+  {
+    value: "application_type",
+    label: "Application type",
+    values: [
+      "Mobile Application",
+      "Web Application",
+      "Desktop Application",
+      "BackEnd Application",
+      "Other",
+    ],
+  },
+  {
+    value: "complexity",
+    label: "Complexity",
+    values: ["High", "Medium", "Low", "Critical", "Unknown"],
+  },
+  {
+    value: "criticality",
+    label: "Criticality",
+    values: ["High", "Medium", "Low", "Critical", "Unknown"],
+  },
+  {
+    value: "effort",
+    label: "Effort",
+    values: ["High", "Medium", "Low", "Critical", "Unknown"],
+  },
+  {
+    value: "hosting",
+    label: "Hosting",
+    values: [
+      "Engineering Data Center",
+      "GCP (Go Reply)",
+      "Standalone",
+      "Azure (Arcese)",
+      "Supplier Private Cloud",
+      "Azure (Microsoft)",
+    ],
+  },
+  {
+    value: "bi",
+    label: "BI",
+    values: [
+      "Unknown",
+      "Actual BI",
+      "To manage",
+      "Partial BI",
+      "Data Platform",
+    ],
+  },
+  {
+    value: "user_license_type",
+    label: "User license type",
+    values: [
+      "Licenza concorrente",
+      "Licenza nominale",
+      "Licenza non applicata all'utente",
+      "Nessuna licenza",
+    ],
+  },
+  {
+    value: "ams_service",
+    label: "AMS service",
+    values: ["No", "On Demand"],
+  },
+];
+
+const edgeFieldOptions: FieldOption[] = [
+  {
+    value: "communication_mode",
+    label: "Communication mode",
+    values: ["Synchronous", "Asynchronous"],
+  },
+  {
+    value: "message_format",
+    label: "Message format",
+    values: [
+      "binary",
+      "csv",
+      "doc",
+      "image",
+      "json",
+      "pdf",
+      "text",
+      "xml",
+      "multiple-formats",
+      "unknown",
+    ],
+  },
+  {
+    value: "protocol",
+    label: "Protocol",
+    values: [
+      "api",
+      "cdc:debezium",
+      "db",
+      "db:stored-procedure",
+      "edi:generic",
+      "email",
+      "folder",
+      "ftp",
+      "http",
+      "http:azure-blob-storage",
+      "human-manual-task",
+      "ldap",
+      "queue",
+      "queue:azure-service-bus",
+      "soap",
+      "topic",
+      "topic:kafka",
+      "wcf",
+      "web-api",
+      "unknown",
+    ],
+  },
+  {
+    value: "intent",
+    label: "Intent",
+    values: [
+      "read",
+      "write",
+      "read:query",
+      "read:dequeue",
+      "read:subscribe",
+      "write:command",
+      "write:insert",
+      "write:enqueue",
+      "write:publish",
+      "unknown",
+    ],
+  },
+  {
+    value: "data_flow",
+    label: "Data flow",
+    values: ["in", "out"],
+  },
+];
 
 interface ColorConfigDialogProps {
   open: boolean;
@@ -24,10 +175,12 @@ function RuleSection({
   title,
   rules,
   setRules,
+  fieldOptions,
 }: {
   title: string;
   rules: ColorRule[];
   setRules: (rules: ColorRule[]) => void;
+  fieldOptions: FieldOption[];
 }) {
   const updateRule = (index: number, key: keyof ColorRule, value: string) => {
     const updated = rules.map((r, i) => (i === index ? { ...r, [key]: value } : r));
@@ -45,29 +198,53 @@ function RuleSection({
   return (
     <div className="space-y-2 mb-4">
       <h3 className="font-semibold">{title}</h3>
-      {rules.map((rule, idx) => (
-        <div key={idx} className="grid grid-cols-4 gap-2 items-center">
-          <Input
-            value={rule.field}
-            onChange={(e) => updateRule(idx, "field", e.target.value)}
-            placeholder="Field"
-          />
-          <Input
-            value={rule.value}
-            onChange={(e) => updateRule(idx, "value", e.target.value)}
-            placeholder="Value"
-          />
-          <input
-            type="color"
-            value={rule.color}
-            onChange={(e) => updateRule(idx, "color", e.target.value)}
-            className="h-10 w-full rounded-md border"
-          />
-          <Button variant="ghost" size="sm" onClick={() => removeRule(idx)}>
-            Remove
-          </Button>
-        </div>
-      ))}
+      {rules.map((rule, idx) => {
+        const values = fieldOptions.find((f) => f.value === rule.field)?.values || [];
+        return (
+          <div key={idx} className="grid grid-cols-4 gap-2 items-center">
+            <Select
+              value={rule.field}
+              onValueChange={(v) => updateRule(idx, "field", v)}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Field" />
+              </SelectTrigger>
+              <SelectContent>
+                {fieldOptions.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select
+              value={rule.value}
+              onValueChange={(v) => updateRule(idx, "value", v)}
+              disabled={!rule.field}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Value" />
+              </SelectTrigger>
+              <SelectContent>
+                {values.map((val) => (
+                  <SelectItem key={val} value={val}>
+                    {val}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <input
+              type="color"
+              value={rule.color}
+              onChange={(e) => updateRule(idx, "color", e.target.value)}
+              className="h-10 w-full rounded-md border"
+            />
+            <Button variant="ghost" size="sm" onClick={() => removeRule(idx)}>
+              Remove
+            </Button>
+          </div>
+        );
+      })}
       <Button variant="outline" size="sm" onClick={addRule}>
         Add rule
       </Button>
@@ -90,8 +267,18 @@ export function ColorConfigDialog({
           <DialogTitle>Color configuration</DialogTitle>
         </DialogHeader>
         <ScrollArea className="flex-1 px-1 py-2">
-          <RuleSection title="Applications" rules={nodeRules} setRules={setNodeRules} />
-          <RuleSection title="Flows" rules={edgeRules} setRules={setEdgeRules} />
+          <RuleSection
+            title="Applications"
+            rules={nodeRules}
+            setRules={setNodeRules}
+            fieldOptions={nodeFieldOptions}
+          />
+          <RuleSection
+            title="Flows"
+            rules={edgeRules}
+            setRules={setEdgeRules}
+            fieldOptions={edgeFieldOptions}
+          />
         </ScrollArea>
         <div className="flex justify-end gap-2">
           <Button variant="outline" onClick={() => onOpenChange(false)}>

--- a/components/ColorConfigDialog.tsx
+++ b/components/ColorConfigDialog.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+export interface ColorRule {
+  field: string;
+  value: string;
+  color: string;
+}
+
+interface ColorConfigDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  nodeRules: ColorRule[];
+  setNodeRules: (rules: ColorRule[]) => void;
+  edgeRules: ColorRule[];
+  setEdgeRules: (rules: ColorRule[]) => void;
+}
+
+function RuleSection({
+  title,
+  rules,
+  setRules,
+}: {
+  title: string;
+  rules: ColorRule[];
+  setRules: (rules: ColorRule[]) => void;
+}) {
+  const updateRule = (index: number, key: keyof ColorRule, value: string) => {
+    const updated = rules.map((r, i) => (i === index ? { ...r, [key]: value } : r));
+    setRules(updated);
+  };
+
+  const addRule = () => {
+    setRules([...rules, { field: "", value: "", color: "#ff0000" }]);
+  };
+
+  const removeRule = (index: number) => {
+    setRules(rules.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className="space-y-2 mb-4">
+      <h3 className="font-semibold">{title}</h3>
+      {rules.map((rule, idx) => (
+        <div key={idx} className="grid grid-cols-4 gap-2 items-center">
+          <Input
+            value={rule.field}
+            onChange={(e) => updateRule(idx, "field", e.target.value)}
+            placeholder="Field"
+          />
+          <Input
+            value={rule.value}
+            onChange={(e) => updateRule(idx, "value", e.target.value)}
+            placeholder="Value"
+          />
+          <input
+            type="color"
+            value={rule.color}
+            onChange={(e) => updateRule(idx, "color", e.target.value)}
+            className="h-10 w-full rounded-md border"
+          />
+          <Button variant="ghost" size="sm" onClick={() => removeRule(idx)}>
+            Remove
+          </Button>
+        </div>
+      ))}
+      <Button variant="outline" size="sm" onClick={addRule}>
+        Add rule
+      </Button>
+    </div>
+  );
+}
+
+export function ColorConfigDialog({
+  open,
+  onOpenChange,
+  nodeRules,
+  setNodeRules,
+  edgeRules,
+  setEdgeRules,
+}: ColorConfigDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[600px] h-[80vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle>Color configuration</DialogTitle>
+        </DialogHeader>
+        <ScrollArea className="flex-1 px-1 py-2">
+          <RuleSection title="Applications" rules={nodeRules} setRules={setNodeRules} />
+          <RuleSection title="Flows" rules={edgeRules} setRules={setEdgeRules} />
+        </ScrollArea>
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/components/NetworkGraph.tsx
+++ b/components/NetworkGraph.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { Network } from "vis-network";
 import { executeQuery } from "@/lib/neo4j";
-import { AppWindow, Link as Line, Magnet } from "lucide-react";
+import { AppWindow, Link as Line, Magnet, Palette } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -15,6 +15,7 @@ import {
 import { ApplicationForm } from "./ApplicationForm";
 import { FlowForm } from "./FlowForm";
 import { ConfirmModal } from "./ConfirmModal";
+import { ColorConfigDialog, ColorRule } from "./ColorConfigDialog";
 import {
   Tooltip,
   TooltipContent,
@@ -214,6 +215,24 @@ function formatKey(key: string): string {
     .join(" ");
 }
 
+function getNodeColor(rules: ColorRule[], props: Record<string, any>): string | undefined {
+  for (const r of rules) {
+    if (props && props[r.field] !== undefined && String(props[r.field]) === r.value) {
+      return r.color;
+    }
+  }
+  return undefined;
+}
+
+function getEdgeColor(rules: ColorRule[], props: Record<string, any>): string | undefined {
+  for (const r of rules) {
+    if (props && props[r.field] !== undefined && String(props[r.field]) === r.value) {
+      return r.color;
+    }
+  }
+  return undefined;
+}
+
 export function NetworkGraph() {
   const containerRef = useRef<HTMLDivElement>(null);
   const networkRef = useRef<Network | null>(null);
@@ -242,8 +261,26 @@ export function NetworkGraph() {
     data: {},
     type: "",
   });
+  const [isColorDialogOpen, setIsColorDialogOpen] = useState(false);
+  const [nodeColorRules, setNodeColorRules] = useState<ColorRule[]>([]);
+  const [edgeColorRules, setEdgeColorRules] = useState<ColorRule[]>([]);
   const [appLabels, setAppLabels] = useState([]);
   const [flowLabels, setFlowLabels] = useState([]);
+
+  useEffect(() => {
+    const n = localStorage.getItem("nodeColorRules");
+    const e = localStorage.getItem("edgeColorRules");
+    if (n) setNodeColorRules(JSON.parse(n));
+    if (e) setEdgeColorRules(JSON.parse(e));
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem("nodeColorRules", JSON.stringify(nodeColorRules));
+  }, [nodeColorRules]);
+
+  useEffect(() => {
+    localStorage.setItem("edgeColorRules", JSON.stringify(edgeColorRules));
+  }, [edgeColorRules]);
 
   const handleQueryResults = useCallback((results: any[]) => {
     const nodes = new Map();
@@ -260,22 +297,26 @@ export function NetworkGraph() {
       if (nodeA && !nodes.has(nodeA.elementId)) {
         const label =
           nodeA.properties.name || nodeA.properties.nickname || "Unnamed";
+        const nColor = getNodeColor(nodeColorRules, nodeA.properties);
         nodes.set(nodeA.elementId, {
           id: nodeA.elementId,
           label: label,
           title: createNodeTooltip(nodeA.properties),
           group: nodeA.labels[0].toLowerCase(),
+          ...(nColor ? { color: { background: nColor, border: nColor } } : {}),
         });
       }
 
       if (nodeB && !nodes.has(nodeB.elementId)) {
         const label =
           nodeB.properties.name || nodeB.properties.nickname || "Unnamed";
+        const nColor = getNodeColor(nodeColorRules, nodeB.properties);
         nodes.set(nodeB.elementId, {
           id: nodeB.elementId,
           label: label,
           title: createNodeTooltip(nodeB.properties),
           group: nodeB.labels[0].toLowerCase(),
+          ...(nColor ? { color: { background: nColor, border: nColor } } : {}),
         });
       }
 
@@ -284,6 +325,7 @@ export function NetworkGraph() {
         relationship.startNodeElementId &&
         relationship.endNodeElementId
       ) {
+        const eColor = getEdgeColor(edgeColorRules, relationship.properties);
         edges.push({
           id: relationship.elementId,
           from: relationship.startNodeElementId,
@@ -291,6 +333,7 @@ export function NetworkGraph() {
           label: relationship.properties?.name || relationship.type,
           arrows: "to",
           title: createEdgeTooltip(relationship.properties),
+          ...(eColor ? { color: { color: eColor, highlight: eColor } } : {}),
         });
       }
     });
@@ -355,11 +398,13 @@ export function NetworkGraph() {
           const newNode = result[0].a;
 
           if (networkRef.current) {
+            const nColor = getNodeColor(nodeColorRules, newNode.properties);
             const nodeData = {
               id: newNode.elementId,
               label: newNode.properties.name,
               title: createNodeTooltip(newNode.properties),
               group: "application",
+              ...(nColor ? { color: { background: nColor, border: nColor } } : {}),
             };
 
             const network = networkRef.current as NetworkWithBody;
@@ -404,6 +449,7 @@ export function NetworkGraph() {
           const newNode = result[0].f;
 
           if (networkRef.current) {
+            const eColor = getEdgeColor(edgeColorRules, newNode.properties);
             const edgeData = {
               id: newNode.elementId,
               from: newNode.startNodeElementId,
@@ -411,6 +457,7 @@ export function NetworkGraph() {
               label: newNode.properties.name || newNode.type,
               arrows: "to",
               title: createEdgeTooltip(newNode.properties),
+              ...(eColor ? { color: { color: eColor, highlight: eColor } } : {}),
             };
 
             const network = networkRef.current as NetworkWithBody;
@@ -545,12 +592,15 @@ export function NetworkGraph() {
             const x = sourceNodePosition.x + radius * Math.cos(angle);
             const y = sourceNodePosition.y + radius * Math.sin(angle);
 
+            const nColor = getNodeColor(nodeColorRules, node.properties);
+
             const nodeData = {
               id: node.elementId,
               label:
                 node.properties.name || node.properties.nickname || "Unnamed",
               title: createNodeTooltip(node.properties),
               group: node.labels[0].toLowerCase(),
+              ...(nColor ? { color: { background: nColor, border: nColor } } : {}),
               x: x,
               y: y,
             };
@@ -563,6 +613,7 @@ export function NetworkGraph() {
           relationship &&
           !currentDataRef.current.edges.has(relationship.elementId)
         ) {
+          const eColor = getEdgeColor(edgeColorRules, relationship.properties);
           const edgeData = {
             id: relationship.elementId,
             from: relationship.startNodeElementId,
@@ -570,6 +621,7 @@ export function NetworkGraph() {
             label: relationship.properties.name || relationship.type,
             arrows: "to",
             title: createEdgeTooltip(relationship.properties),
+            ...(eColor ? { color: { color: eColor, highlight: eColor } } : {}),
           };
           currentDataRef.current.edges.set(relationship.elementId, edgeData);
           newEdges.push(edgeData);
@@ -846,6 +898,21 @@ export function NetworkGraph() {
                 <p>{isPhysicsEnabled ? "Disable" : "Enable"} physics</p>
               </TooltipContent>
             </Tooltip>
+
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  onClick={() => setIsColorDialogOpen(true)}
+                >
+                  <Palette className="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Configure colors</p>
+              </TooltipContent>
+            </Tooltip>
           </TooltipProvider>
         </div>
 
@@ -1015,6 +1082,15 @@ export function NetworkGraph() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <ColorConfigDialog
+        open={isColorDialogOpen}
+        onOpenChange={setIsColorDialogOpen}
+        nodeRules={nodeColorRules}
+        setNodeRules={setNodeColorRules}
+        edgeRules={edgeColorRules}
+        setEdgeRules={setEdgeColorRules}
+      />
 
       <ConfirmModal
         isOpen={isConfirmModalOpen.show}

--- a/components/NetworkGraph.tsx
+++ b/components/NetworkGraph.tsx
@@ -215,9 +215,18 @@ function formatKey(key: string): string {
     .join(" ");
 }
 
+function matchesRuleValue(prop: any, value: string): boolean {
+  if (prop === undefined || prop === null) return false;
+  const str = String(prop);
+  if (str.includes(',')) {
+    return str.split(',').map((s) => s.trim()).includes(value);
+  }
+  return str === value;
+}
+
 function getNodeColor(rules: ColorRule[], props: Record<string, any>): string | undefined {
   for (const r of rules) {
-    if (props && props[r.field] !== undefined && String(props[r.field]) === r.value) {
+    if (props && matchesRuleValue(props[r.field], r.value)) {
       return r.color;
     }
   }
@@ -226,7 +235,7 @@ function getNodeColor(rules: ColorRule[], props: Record<string, any>): string | 
 
 function getEdgeColor(rules: ColorRule[], props: Record<string, any>): string | undefined {
   for (const r of rules) {
-    if (props && props[r.field] !== undefined && String(props[r.field]) === r.value) {
+    if (props && matchesRuleValue(props[r.field], r.value)) {
       return r.color;
     }
   }


### PR DESCRIPTION
## Summary
- add color configuration dialog
- support custom rules for node and edge colors
- show palette button to open color config
- apply selected colors to created/loaded nodes and edges

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e44475d94832396b082409c4b23f4