### PR TITLE
Add color customization for graph nodes and links

### DIFF
--- a/components/ColorSettingsModal.tsx
+++ b/components/ColorSettingsModal.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useEffect, useState, useMemo } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectTrigger,
+  SelectContent,
+  SelectItem,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface ColorSettings {
+  nodeProperty: string | null;
+  nodeColors: Record<string, string>;
+  edgeProperty: string | null;
+  edgeColors: Record<string, string>;
+}
+
+interface ColorSettingsModalProps {
+  open: boolean;
+  onClose: () => void;
+  data: Record<string, any>;
+  onApply: (settings: ColorSettings) => void;
+}
+
+export function ColorSettingsModal({
+  open,
+  onClose,
+  data,
+  onApply,
+}: ColorSettingsModalProps) {
+  const [nodeProperty, setNodeProperty] = useState<string | null>(null);
+  const [edgeProperty, setEdgeProperty] = useState<string | null>(null);
+  const [nodeColors, setNodeColors] = useState<Record<string, string>>({});
+  const [edgeColors, setEdgeColors] = useState<Record<string, string>>({});
+
+  const nodeProperties = useMemo(() => {
+    const props = new Set<string>();
+    Object.values(data).forEach((item: any) => {
+      if (item.labels) {
+        Object.keys(item).forEach((k) => {
+          if (!["labels", "elementId", "type"].includes(k)) props.add(k);
+        });
+      }
+    });
+    return Array.from(props);
+  }, [data]);
+
+  const edgeProperties = useMemo(() => {
+    const props = new Set<string>();
+    Object.values(data).forEach((item: any) => {
+      if (item.type) {
+        Object.keys(item).forEach((k) => {
+          if (!["type", "initiator_application", "target_application"].includes(k))
+            props.add(k);
+        });
+      }
+    });
+    return Array.from(props);
+  }, [data]);
+
+  const nodeValues = useMemo(() => {
+    if (!nodeProperty) return [] as string[];
+    const vals = new Set<string>();
+    Object.values(data).forEach((item: any) => {
+      if (item.labels && item[nodeProperty] !== undefined) {
+        vals.add(String(item[nodeProperty]));
+      }
+    });
+    return Array.from(vals);
+  }, [data, nodeProperty]);
+
+  const edgeValues = useMemo(() => {
+    if (!edgeProperty) return [] as string[];
+    const vals = new Set<string>();
+    Object.values(data).forEach((item: any) => {
+      if (item.type && item[edgeProperty] !== undefined) {
+        vals.add(String(item[edgeProperty]));
+      }
+    });
+    return Array.from(vals);
+  }, [data, edgeProperty]);
+
+  useEffect(() => {
+    const colors: Record<string, string> = {};
+    nodeValues.forEach((v) => {
+      colors[v] = nodeColors[v] || "#ff0000";
+    });
+    setNodeColors(colors);
+  }, [nodeValues]);
+
+  useEffect(() => {
+    const colors: Record<string, string> = {};
+    edgeValues.forEach((v) => {
+      colors[v] = edgeColors[v] || "#ff0000";
+    });
+    setEdgeColors(colors);
+  }, [edgeValues]);
+
+  const handleApply = () => {
+    onApply({ nodeProperty, nodeColors, edgeProperty, edgeColors });
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-[600px] z-[700]">
+        <DialogHeader>
+          <DialogTitle>Color settings</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-6 max-h-[60vh] overflow-y-auto">
+          <div>
+            <h3 className="font-semibold mb-2">Applications</h3>
+            <Select value={nodeProperty || undefined} onValueChange={setNodeProperty}>
+              <SelectTrigger>
+                <SelectValue placeholder="Select property" />
+              </SelectTrigger>
+              <SelectContent>
+                {nodeProperties.map((p) => (
+                  <SelectItem key={p} value={p}>
+                    {p}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {nodeProperty && (
+              <div className="mt-4 space-y-2">
+                {nodeValues.map((val) => (
+                  <div key={val} className="flex items-center gap-2">
+                    <span className="flex-1 text-sm">{val}</span>
+                    <input
+                      type="color"
+                      value={nodeColors[val]}
+                      onChange={(e) =>
+                        setNodeColors((prev) => ({ ...prev, [val]: e.target.value }))
+                      }
+                      className="w-8 h-8 p-0 border rounded"
+                    />
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+          <div>
+            <h3 className="font-semibold mb-2">Flows</h3>
+            <Select value={edgeProperty || undefined} onValueChange={setEdgeProperty}>
+              <SelectTrigger>
+                <SelectValue placeholder="Select property" />
+              </SelectTrigger>
+              <SelectContent>
+                {edgeProperties.map((p) => (
+                  <SelectItem key={p} value={p}>
+                    {p}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {edgeProperty && (
+              <div className="mt-4 space-y-2">
+                {edgeValues.map((val) => (
+                  <div key={val} className="flex items-center gap-2">
+                    <span className="flex-1 text-sm">{val}</span>
+                    <input
+                      type="color"
+                      value={edgeColors[val]}
+                      onChange={(e) =>
+                        setEdgeColors((prev) => ({ ...prev, [val]: e.target.value }))
+                      }
+                      className="w-8 h-8 p-0 border rounded"
+                    />
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+        <DialogFooter className="mt-4">
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleApply}>Apply</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/components/HelpPage.tsx
+++ b/components/HelpPage.tsx
@@ -61,7 +61,7 @@ export function HelpPage() {
                   <p className="text-muted-foreground">
                     Contact information should be provided as JSON arrays, for example:
                     <code className="block bg-muted p-2 rounded-md mt-2">
-                      ["contact1@example.com", "contact2@example.com"]
+                      [&quot;contact1@example.com&quot;, &quot;contact2@example.com&quot;]
                     </code>
                   </p>
                 </section>

--- a/components/NetworkGraph.tsx
+++ b/components/NetworkGraph.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { Network } from "vis-network";
 import { executeQuery } from "@/lib/neo4j";
-import { AppWindow, Link as Line, Magnet } from "lucide-react";
+import { AppWindow, Link as Line, Magnet, Palette } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -36,6 +36,7 @@ import {
   getApplicationLabels
 } from "@/lib/neo4jUtils";
 import { MultiselectDropdown } from "./MultiselectDropdown";
+import { ColorSettingsModal } from "./ColorSettingsModal";
 
 interface NetworkWithBody extends Network {
   body: {
@@ -244,6 +245,13 @@ export function NetworkGraph() {
   });
   const [appLabels, setAppLabels] = useState([]);
   const [flowLabels, setFlowLabels] = useState([]);
+  const [isColorModalOpen, setIsColorModalOpen] = useState(false);
+  const [colorSettings, setColorSettings] = useState({
+    nodeProperty: null,
+    nodeColors: {},
+    edgeProperty: null,
+    edgeColors: {},
+  } as any);
 
   const handleQueryResults = useCallback((results: any[]) => {
     const nodes = new Map();
@@ -365,6 +373,7 @@ export function NetworkGraph() {
             const network = networkRef.current as NetworkWithBody;
             network.body.data.nodes.add(nodeData);
             currentDataRef.current.nodes.set(newNode.elementId, nodeData);
+            applyColorSettings(colorSettings);
           }
 
           const newApp = transformData(result);
@@ -416,6 +425,7 @@ export function NetworkGraph() {
             const network = networkRef.current as NetworkWithBody;
             network.body.data.edges.add(edgeData);
             currentDataRef.current.edges.set(newNode.elementId, edgeData);
+            applyColorSettings(colorSettings);
           }
 
           const newApp = transformData(result);
@@ -508,6 +518,42 @@ export function NetworkGraph() {
     }
   }, [isPhysicsEnabled]);
 
+  const applyColorSettings = useCallback(
+    (settings: any) => {
+      if (!networkRef.current) return;
+      const nodeUpdates: any[] = [];
+      currentDataRef.current.nodes.forEach((node) => {
+        const props = dataTransformedRef.current[node.id];
+        let color = null;
+        if (settings.nodeProperty && props && props.labels) {
+          const val = String(props[settings.nodeProperty] ?? "");
+          const c = settings.nodeColors[val];
+          if (c) {
+            color = { background: c, border: c };
+          }
+        }
+        nodeUpdates.push({ id: node.id, color });
+      });
+      networkRef.current.body.data.nodes.update(nodeUpdates);
+
+      const edgeUpdates: any[] = [];
+      currentDataRef.current.edges.forEach((edge) => {
+        const props = dataTransformedRef.current[edge.id];
+        let color = null;
+        if (settings.edgeProperty && props) {
+          const val = String(props[settings.edgeProperty] ?? "");
+          const c = settings.edgeColors[val];
+          if (c) {
+            color = { color: c, highlight: c };
+          }
+        }
+        edgeUpdates.push({ id: edge.id, color });
+      });
+      networkRef.current.body.data.edges.update(edgeUpdates);
+    },
+    []
+  );
+
   const expandNode = async (nodeId: string) => {
     if (!networkRef.current) return;
     const network = networkRef.current as NetworkWithBody;
@@ -597,6 +643,10 @@ export function NetworkGraph() {
       }
 
       if (newNodes.length > 0 || newEdges.length > 0) {
+        applyColorSettings(colorSettings);
+      }
+
+      if (newNodes.length > 0 || newEdges.length > 0) {
         setTimeout(() => {
           if (networkRef.current) {
             networkRef.current.setOptions({
@@ -648,6 +698,8 @@ export function NetworkGraph() {
         options
       );
 
+      applyColorSettings(colorSettings);
+
       networkRef.current.on("dragStart", () => {
         networkRef.current?.setOptions({ physics: { enabled: false } });
       });
@@ -696,7 +748,7 @@ export function NetworkGraph() {
     } catch (error) {
       console.error("Error initializing network:", error);
     }
-  }, [graphData]);
+  }, [graphData, colorSettings, applyColorSettings, expandNode]);
 
   useEffect(() => {
     if (!isApplicationDialogOpen) {
@@ -749,6 +801,10 @@ export function NetworkGraph() {
   useEffect(() => {
     dataTransformedRef.current = dataTransformed;
   }, [dataTransformed]);
+
+  useEffect(() => {
+    applyColorSettings(colorSettings);
+  }, [colorSettings, applyColorSettings]);
 
 
   /* Gestione Dropdown */
@@ -863,6 +919,21 @@ export function NetworkGraph() {
               </TooltipTrigger>
               <TooltipContent>
                 <p>{isPhysicsEnabled ? "Disable" : "Enable"} physics</p>
+              </TooltipContent>
+            </Tooltip>
+
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  onClick={() => setIsColorModalOpen(true)}
+                >
+                  <Palette className="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Color settings</p>
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
@@ -1045,6 +1116,13 @@ export function NetworkGraph() {
         description={`Are you sure you want to delete this ${isConfirmModalOpen.type}? This action cannot be undone.`}
         confirmText="Delete"
         cancelText="Cancel"
+      />
+
+      <ColorSettingsModal
+        open={isColorModalOpen}
+        onClose={() => setIsColorModalOpen(false)}
+        data={dataTransformed}
+        onApply={(settings) => setColorSettings(settings)}
       />
     </div>
   );

--- a/components/RichTextEditor.tsx
+++ b/components/RichTextEditor.tsx
@@ -13,7 +13,7 @@ const CKEditor = dynamic(
   async () => {
     const { CKEditor } = await import("@ckeditor/ckeditor5-react");
     const { default: ClassicEditor } = await import("@ckeditor/ckeditor5-build-classic");
-    return ({ data, onReady, onChange, config }: any) => (
+    const EditorComponent = ({ data, onReady, onChange, config }: any) => (
       <CKEditor
         editor={ClassicEditor as any}
         data={data}
@@ -22,6 +22,8 @@ const CKEditor = dynamic(
         config={config}
       />
     );
+    EditorComponent.displayName = "CKEditorComponent";
+    return EditorComponent;
   },
   {
     ssr: false,
@@ -93,3 +95,5 @@ export function RichTextEditor({ value, onChange, placeholder }: RichTextEditorP
     </div>
   );
 }
+
+RichTextEditor.displayName = "RichTextEditor";


### PR DESCRIPTION
## Summary
- implement `ColorSettingsModal` for selecting properties and colors
- integrate modal with `NetworkGraph`
- allow runtime coloring of nodes and edges
- fix lint errors in `HelpPage` and `RichTextEditor`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6867c945800c8323b8a671a6cbd45cc0