### PR TITLE
Add default color configuration for graph

### DIFF
--- a/components/ColorConfigModal.tsx
+++ b/components/ColorConfigModal.tsx
@@ -55,6 +55,31 @@ const ColorConfigModal: React.FC<ColorConfigModalProps> = ({
       return out;
     };
     if (!initialConfig) {
+      if (et === "Application") {
+        return {
+          selectedField: applicationFields.find((f) => f.name === "criticality") || null,
+          colorConfig: {
+            High: { background: "#f44336", border: "#f44336" },
+            Medium: { background: "#ff9800", border: "#ff9800" },
+            Low: { background: "#4caf50", border: "#4caf50" },
+            Critical: { background: "#ff0000", border: "#ff0000" },
+            Unknown: { background: "#9e9e9e", border: "#9e9e9e" },
+          },
+          textInputValue: "",
+          dateInputValues: { before: "", at: "", after: "" },
+        };
+      }
+      if (et === "Flow") {
+        return {
+          selectedField: flowFields.find((f) => f.name === "intent") || null,
+          colorConfig: {
+            read: { background: "#4caf50", border: "#4caf50" },
+            write: { background: "#f44336", border: "#f44336" },
+          },
+          textInputValue: "",
+          dateInputValues: { before: "", at: "", after: "" },
+        };
+      }
       return {
         selectedField: null,
         colorConfig: {},

--- a/components/NetworkGraph.tsx
+++ b/components/NetworkGraph.tsx
@@ -250,6 +250,26 @@ export function NetworkGraph() {
   const [isValueFilterModalOpen, setisValueFilterModalOpen] =
     useState<any>(false);
 
+  const defaultColorConfig = {
+    Application: {
+      fieldName: "criticality",
+      colorConfig: {
+        High: { background: "#f44336", border: "#f44336" },
+        Medium: { background: "#ff9800", border: "#ff9800" },
+        Low: { background: "#4caf50", border: "#4caf50" },
+        Critical: { background: "#ff0000", border: "#ff0000" },
+        Unknown: { background: "#9e9e9e", border: "#9e9e9e" },
+      },
+    },
+    Flow: {
+      fieldName: "intent",
+      colorConfig: {
+        read: { background: "#4caf50", border: "#4caf50" },
+        write: { background: "#f44336", border: "#f44336" },
+      },
+    },
+  };
+
   const [colorConfig, setColorConfig] = useState<{
     Application?: {
       fieldName: string;
@@ -259,7 +279,7 @@ export function NetworkGraph() {
       fieldName: string;
       colorConfig: Record<string, { background: string; border: string }>;
     };
-  }>({});
+  }>(defaultColorConfig);
 
   const handleQueryResults = useCallback(
     (results: any[]) => {


### PR DESCRIPTION
## Summary
- provide default color values in `ColorConfigModal`
- add same default color config when initializing `NetworkGraph`

## Testing
- `npx next lint` *(fails: react/no-unescaped-entities etc.)*
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6875eb4e768c83239eb86af2a06725bf